### PR TITLE
Datentyp für XP_Objekt.text von varchar(255) zu text geändert.

### DIFF
--- a/XP_Basisschema.sql
+++ b/XP_Basisschema.sql
@@ -1368,7 +1368,7 @@ COMMENT ON COLUMN "XP_Basisobjekte"."XP_WirksamkeitBedingung"."datumRelativ" IS 
 CREATE  TABLE  "XP_Basisobjekte"."XP_Objekt" (
   "gid" BIGINT NOT NULL DEFAULT nextval('"XP_Basisobjekte"."XP_Objekt_gid_seq"'),
   "uuid" VARCHAR(64) NULL ,
-  "text" VARCHAR(255) NULL ,
+  "text" text NULL ,
   "rechtsstand" INTEGER NULL ,
   "gesetzlicheGrundlage" INTEGER NULL ,
   "gliederung1" VARCHAR(255) NULL ,

--- a/fix_52.sql
+++ b/fix_52.sql
@@ -211,6 +211,13 @@ ALTER TABLE "XP_Basisobjekte"."XP_Bereich_refScan" ADD CONSTRAINT "fk_XP_Bereich
 ALTER TABLE "FP_Basisobjekte"."FP_Plan" RENAME "aufstellungsbechlussDatum" TO "aufstellungsbeschlussDatum";
 COMMENT ON COLUMN "FP_Basisobjekte"."FP_Plan"."aufstellungsbeschlussDatum" IS 'Datum des Plan-Aufstellungsbeschlusses.';
 
+-- ändere datentyp varchar(255) zu text
+-- -----------------------------------------------------
+-- Table "XP_Basisobjekte"."XP_Objekt"
+-- -----------------------------------------------------
+ALTER TABLE "XP_Basisobjekte"."XP_Objekt" ALTER COLUMN "text" SET DATA TYPE text;
+
+
 -- füge fehlendes Attribut XP_Objekt.refBegruendungInhalt ein
 -- -----------------------------------------------------
 -- Table "XP_Basisobjekte"."XP_Objekt_refBegruendungInhalt"


### PR DESCRIPTION
Hi,

ich habe Experimente mit den Duisburger XPlanungs-Daten gemacht und dabei festgestellt, dass das Attribut in "XP_Basisobjekte"."XP_Objekt".text deutlich längeren text enthält als in ein varchar(255) hineinpasst.

z.B.: "In Gebieten der offenen und geschlossenen Bauweise ist an Nachbargrenzen die Errichtung von durchsichtigen Einfriedigungen oder Hecken bis zu einer Höhe von 1,25 m zulässig. In WR-Gebieten darf die Gebäudetiefe 12,0 m nicht überschreiten. Die Gebäudetiefe ist von den im Bebauungsplan festgesetzten verkehrsflächenseitigen Baugrenzen bzw. Baulinien ab zu ermitteln."

Ich habe den Datensatz "578 1. Änderung Buchholz" aus https://opendata-duisburg.de/dataset/bebauungspl%C3%A4ne-xplanung verarbeitet

Nachdem ich die überholte schemaLocation in der xplanungs-gml-datei noch angepasst hatte (xsi:schemaLocation="http://www.xplanung.de/xplangml/5/1 https://xleitstelle.de/downloads/xplanung/releases/XPlanung%20Version%205.1.2/XPlanung-Operationen.xsd" --führt durch fehlende Schema-Dependencies ins leere), konnte ich den Datensatz aber immer noch nicht importieren. Es gab folgende Fehlermeldung:

```log
2022-06-27T11:29:19     CRITICAL    ERROR: value too long for type character varying(255)
             (22001) QPSQL: Unable to create query
2022-06-27T11:29:19     CRITICAL    UPDATE "XP_Basisobjekte"."XP_Objekt" ziel SET ("uuid","text","rechtsstand","gliederung1","gliederung2","ebene","aufschrift") = (SELECT COALESCE("uuid",id)::varchar,"text"::varchar,"rechtsstand"::int4,"gliederung1"::varchar,"gliederung2"::varchar,"ebene"::int4,"aufschrift"::varchar FROM "aenderung_buchholz_test"."bp_ueberbaubaregrundstuecksflaeche" quelle WHERE quelle.xp_gid = ziel.gid) WHERE gid IN (SELECT xp_gid FROM "aenderung_buchholz_test"."bp_ueberbaubaregrundstuecksflaeche");
```

Erst mit der Datenbankanpassung aus diesem Pull-Request war der Import erfolgreich.